### PR TITLE
Adds support for CSS source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Task targets, files and options may be specified according to the grunt [Configu
 
 #### Source Files
 
-The source files for this task should be a JavaScript source file that contains or references an external source map.
+The source files for this task should be a JavaScript or CSS source file that contains or references an external source map.
 The source file should be from the *final* step in the compilation process.
 `merge-source-maps` will follow the chain of source maps to the beginning.
 
@@ -69,7 +69,8 @@ Type: `Boolean`
 
 Default: `false`
 
-If `true`, inlines the source map into the generated JavaScript. The `dest` file for each `src` file *must* be the path to the generated JavaScript.
+If `true`, inlines the source map into the generated JavaScript or CSS file.
+The `dest` file for each `src` file *must* be the path to the generated JavaScript/CSS.
 
 ### ignoreMissingSourceMaps (--ignore-missing-source-maps)
 
@@ -85,8 +86,8 @@ Below, we illustrate various useful configurations.
 
 ### Inlined source maps and sources
 
-With this setup, the source map *and* the source code of your project will be embedded directly into the generated JavaScript file.
-Thus, the JavaScript file alone is all that is needed to debug your program with source maps, provided the debugger supports
+With this setup, the source map *and* the source code of your project will be embedded directly into the generated JavaScript or CSS file.
+Thus, the JavaScript or CSS file alone is all that is needed to debug your program with source maps, provided the debugger supports
 embedded source maps.
 Perfect for scenarios where bandwidth is not an issue, such as Node projects or debug builds.
 
@@ -116,9 +117,9 @@ merge-source-maps --inline-source-map --inline-sources build/*.js
 
 ### External source maps with inlined sources
 
-With this setup, the generated JavaScript file will have a corresponding `.map` file that also contains the source code to the program.
-The debugger will only need the JavaScript file and the map file to debug the code with source maps.
-Perfect for production web projects, where you want small, minified JavaScript files but also want to be able to debug the original source code.
+With this setup, the generated JavaScript or CSS file will have a corresponding `.map` file that also contains the source code to the program.
+The debugger will only need the JavaScript or CSS file and the map file to debug the code with source maps.
+Perfect for production web projects, where you want small, minified files but also want to be able to debug the original source code.
 
 Grunt configuration:
 
@@ -145,8 +146,8 @@ merge-source-maps --inline-sources build/*.js
 
 ### External source maps with external sources
 
-With this setup, the generated JavaScript file will have a corresponding `.map` file that references external source code files.
-The debugger will need to fetch the JavaScript file, the `.map` file, and each external source code file before you can debug
+With this setup, the generated JavaScript/CSS file will have a corresponding `.map` file that references external source code files.
+The debugger will need to fetch the JavaScript/CSS file, the `.map` file, and each external source code file before you can debug
 the code with source maps.
 Ideal if you are already planning on hosting the original source files for some reason, as it minimizes redundant information
 embedded within the source map.
@@ -181,9 +182,6 @@ Feel free to send PRs or open issues if `merge-source-maps` is not meeting your 
 
 * **You must not overwrite any of the files produced from previous compilation steps.**
 `merge-source-maps` needs the complete chain of compilation steps to appropriately produce a merged source map.
-* **Currently limited to JavaScript files only.**
-Supporting CSS would be trivial, as the source maps are the same, but the syntax for embedding them is slightly different.
-Open an issue if this is a desired feature, and provide sample files if you can. :)
 * **Your source files and source maps must contain correct paths to external resources on disk (source files and source maps).**
 `merge-source-maps` requires these to be set properly so it can follow the compilation chain back to the original source files.
 * **Your source maps must not use the sections property in the source map.**

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Default: `false`
 
 If `true`, ignores input files that are missing source maps. Otherwise, `merge-source-maps` will treat this event as a fatal error.
 
+### ignoreMissingSources (--ignore-missing-sources)
+
+Type: `Boolean`
+
+Default: `false`
+
+If `true`, ignores missing input files referenced by source maps. Otherwise, `merge-source-maps` will treat this event as a fatal error.
+
 ## Usage Examples
 
 Below, we illustrate various useful configurations.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@ export interface ISourceMapMergerConfig {
   inlineSources?: boolean;
   inlineSourceMap?: boolean;
   ignoreMissingSourceMaps?: boolean;
+  ignoreMissingSources?: boolean;
 }
 
 export interface IFile {
@@ -16,11 +17,12 @@ export interface IFile {
 const defaultOptions: ISourceMapMergerConfig = {
   inlineSources: false,
   inlineSourceMap: false,
-  ignoreMissingSourceMaps: false
+  ignoreMissingSourceMaps: false,
+  ignoreMissingSources: false
 };
 
 function mergeFile(file: IFile, config: ISourceMapMergerConfig): void {
-  const sourceFile = new SourceFile(file.src);
+  const sourceFile = new SourceFile(file.src, config);
   if (sourceFile.getMap() !== null) {
     // Merge all of the sources together.
     const map = sourceFile.getMap();

--- a/lib/source_file.ts
+++ b/lib/source_file.ts
@@ -1,8 +1,10 @@
 import fs = require('fs');
 import path = require('path');
 import SourceMapModule = require("source-map");
+import {ISourceMapMergerConfig} from './index';
 const mappingUrlPrefix = "# sourceMappingURL=";
 const dataURLPrefix = "data:application/json;base64,";
+const fileProtocolPrefix = "file:/";
 
 /**
  * Represents a source file.
@@ -14,15 +16,18 @@ export class SourceFile {
   private _source: string;
   // The index at which the mapping URL starts. -1 if the file lacks a source map.
   private _urlStart: number;
+  // The closing comment tag for the source map URL comment, if any (used for CSS).
+  private _urlSuffix = '';
 
   // The source map for this SourceFile, if any. null if it does not exist.
   private _map: SourceMap = null;
 
-  constructor(generatedFilePath: string) {
+  constructor(generatedFilePath: string, config: ISourceMapMergerConfig) {
     this._path = generatedFilePath;
-    this._source = fs.readFileSync(generatedFilePath).toString();
+    const readFile = !config.ignoreMissingSources || fs.existsSync(generatedFilePath);
+    this._source = readFile ? fs.readFileSync(generatedFilePath).toString() : '';
 
-    let prefixIndex = this._source.indexOf(mappingUrlPrefix);
+    let prefixIndex = this._source.lastIndexOf(mappingUrlPrefix);
     if (prefixIndex === -1) {
       // No source map.
       this._urlStart = -1;
@@ -30,6 +35,11 @@ export class SourceFile {
       this._urlStart = prefixIndex + mappingUrlPrefix.length;
 
       let url = this._source.slice(this._urlStart).trim();
+      if (url.slice(-3) === ' */') {
+          url = url.slice(0, -2).trim();
+          this._urlSuffix = ' */';
+      }
+
       switch (url[0]) {
         case '"':
         case "'":
@@ -59,7 +69,7 @@ export class SourceFile {
   public getSource(): string { return this._source; }
 
   public setMappingURL(url: string): void {
-    this._source = `${this._source.slice(0, this._urlStart)}${url}`;
+    this._source = `${this._source.slice(0, this._urlStart)}${url}${this._urlSuffix}`;
     this._map = this.getMapFromUrl(url);
   }
 
@@ -124,6 +134,23 @@ export class SourceMap {
     });
   }
 
+  /**
+   * The reference Sass implementation, dart-sass, outputs file:// absolute
+   * URLs in its source maps in many cases. This method makes those into
+   * relative URLs like we expect everywhere else. For discussion, see
+   * https://github.com/sindresorhus/grunt-sass/issues/299#issuecomment-688802356
+   */
+  public fixSassSources(sourcePath: string): string {
+    const fileProtocolStart = sourcePath.indexOf(fileProtocolPrefix);
+    if (fileProtocolStart !== -1) {
+      sourcePath = sourcePath
+        .slice(fileProtocolStart + fileProtocolPrefix.length)
+        .replace(path.dirname(this._path), '')
+        .replace(/^\/*/, sourcePath[0] === '/' ? '/' : '');
+    }
+    return sourcePath;
+  }
+
   public getFile(): SourceFile {
     return this._file;
   }
@@ -137,7 +164,7 @@ export class SourceMap {
    */
   public getAbsoluteSourcePaths(): string[] {
     return this._map.sources.map(
-      (source) => path.resolve(this.getAbsoluteSourceRoot(), source)
+      (source) => path.resolve(this.getAbsoluteSourceRoot(), this.fixSassSources(source))
     );
   }
 
@@ -149,7 +176,7 @@ export class SourceMap {
   }
 
   public getRelativePath(p: string): string {
-    return path.relative(path.dirname(this._path), p);
+    return path.relative(path.dirname(this._path), this.fixSassSources(p));
   }
 
   /**

--- a/lib/source_file.ts
+++ b/lib/source_file.ts
@@ -22,7 +22,7 @@ export class SourceFile {
   // The source map for this SourceFile, if any. null if it does not exist.
   private _map: SourceMap = null;
 
-  constructor(generatedFilePath: string, config: ISourceMapMergerConfig) {
+  constructor(generatedFilePath: string, private config: ISourceMapMergerConfig) {
     this._path = generatedFilePath;
     const readFile = !config.ignoreMissingSources || fs.existsSync(generatedFilePath);
     this._source = readFile ? fs.readFileSync(generatedFilePath).toString() : '';
@@ -61,7 +61,7 @@ export class SourceFile {
       mapPath = path.resolve(path.dirname(this._path), url);
       mapContents = fs.readFileSync(mapPath).toString();
     }
-    return new SourceMap(this, JSON.parse(mapContents), mapPath);
+    return new SourceMap(this, JSON.parse(mapContents), mapPath, this.config);
   }
 
   public getPath(): string { return this._path; }
@@ -116,7 +116,7 @@ export class SourceMap {
   private _sourceFileMap: {[p: string]: SourceFile};
   private _consumer: SourceMapModule.SourceMapConsumer;
 
-  constructor(file: SourceFile, map: SourceMapModule.RawSourceMap, mapPath: string) {
+  constructor(file: SourceFile, map: SourceMapModule.RawSourceMap, mapPath: string, private config: ISourceMapMergerConfig) {
     this._file = file;
     this._path = mapPath;
     this._updateMap(map);
@@ -127,7 +127,7 @@ export class SourceMap {
     this._consumer = new SourceMapModule.SourceMapConsumer(map);
     this._sourceFileMap = {};
     this._sourceFiles = this.getAbsoluteSourcePaths().map((sourcePath) => {
-      const m = new SourceFile(sourcePath);
+      const m = new SourceFile(sourcePath, this.config);
       // Map relative path to sourcefile.
       this._sourceFileMap[sourcePath] = m;
       return m;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "@types/source-map": "^0.1.29",
     "@types/underscore": "^1.7.33",
     "@types/yargs": "^6.3.0",
-    "typescript": "^2.0.7"
+    "typescript": "^3"
   }
 }


### PR DESCRIPTION
I am experimenting with importing CSS (compiled from SCSS) into TypeScript and needed this functionality.

I had to bump the TypeScript version because `npm install` failed with TypeScript v2.

While I was in there I addressed #1 as well (an option to not fail if source files are missing).

Let me know if there's something I should change!