### PR TITLE
Update yargs

### DIFF
--- a/bin/merge-source-maps.ts
+++ b/bin/merge-source-maps.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-import yargs = require('yargs');
+import yargs = require('yargs/yargs')(process.argv.slice(2));
 import mergeSourceMaps = require('../lib/index');
 import ISourceMapMergerConfig = mergeSourceMaps.ISourceMapMergerConfig;
 

--- a/bin/merge-source-maps.ts
+++ b/bin/merge-source-maps.ts
@@ -1,5 +1,5 @@
 #! /usr/bin/env node
-import yargs = require('yargs/yargs')(process.argv.slice(2));
+const yargs = require('yargs/yargs')(process.argv.slice(2));
 import mergeSourceMaps = require('../lib/index');
 import ISourceMapMergerConfig = mergeSourceMaps.ISourceMapMergerConfig;
 

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   "dependencies": {
     "source-map": "^0.5.6",
     "underscore": "^1.8.3",
-    "yargs": "^6.3.0"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "@types/grunt": "^0.4.20",
     "@types/node": "^6.0.46",
     "@types/source-map": "^0.1.29",
     "@types/underscore": "^1.7.33",
-    "@types/yargs": "^6.3.0",
+    "@types/yargs": "^16.0.1",
     "typescript": "^3"
   }
 }


### PR DESCRIPTION
`npm audit` reports:

```
yargs-parser  <=13.1.1 || 14.0.0 - 15.0.0 || 16.0.0 - 18.1.1
Prototype Pollution - https://npmjs.com/advisories/1500
No fix available
node_modules/yargs/node_modules/yargs-parser
  yargs  4.0.0-alpha1 - 12.0.5 || 14.1.0 || 15.0.0 - 15.2.0
  Depends on vulnerable versions of yargs-parser
  node_modules/yargs
    merge-source-maps  *
    Depends on vulnerable versions of yargs
    node_modules/merge-source-maps
```

This PR fixes that issue by upgrading `yargs`.